### PR TITLE
Preserve .json tokens in FoldDataset normalization (0.5.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alphapulldown-input-parser"
-version = "0.5.0"
+version = "0.5.1"
 description = "Fold specification parser for AlphaPulldown"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/alphapulldown_input_parser/parser.py
+++ b/src/alphapulldown_input_parser/parser.py
@@ -22,6 +22,22 @@ def _strip_path_and_extension(value: str) -> str:
     return Path(value).stem
 
 
+def _normalize_reference_name(value: str) -> str:
+    """Normalize a fold token's name for use as a chain identifier.
+
+    The directory path is always dropped. A ``.json`` extension is *preserved*
+    because such tokens are direct AlphaFold 3 JSON inputs (e.g. ligands), not
+    proteins to fetch or build features for; stripping it would make them
+    indistinguishable from a protein named ``<stem>`` downstream (this is the
+    cause of AlphaPulldownSnakemake issue #41). Any other extension is stripped,
+    matching the historical behaviour for protein references given as file paths.
+    """
+    name = Path(value).name
+    if name.lower().endswith(".json"):
+        return name
+    return _strip_path_and_extension(value)
+
+
 def _format_error(spec: str, msg: str | None = None) -> None:
     """Mirror the historical AlphaPulldown error message."""
     base = f"Your format: {spec} is wrong. The program will terminate."
@@ -139,7 +155,7 @@ class FoldDataset:
                 protein_reference = parts[0]
                 referenced_sequences.append(protein_reference)
 
-                base_name = _strip_path_and_extension(protein_reference)
+                base_name = _normalize_reference_name(protein_reference)
                 per_fold_sequences.append(base_name)
                 suffix_components = [part for part in parts[1:] if part]
                 normalized_tokens.append(

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -399,3 +399,29 @@ def test_parse_fold_chains_custom_delimiter_and_whitespace() -> None:
         ("A", 1, RegionSelection.all()),
         ("B", 1, RegionSelection.all()),
     ]
+
+
+def test_fold_dataset_preserves_json_extension() -> None:
+    """Regression for AlphaPulldownSnakemake #41.
+
+    ``*.json`` tokens are direct AF3 inputs (e.g. ligands), not proteins to fetch
+    or build features for. FoldDataset normalization must keep the ``.json``
+    extension (dropping only the directory) so downstream consumers can still tell
+    them apart from a protein named ``<stem>``, while protein references given as
+    paths are still reduced to their stem.
+    """
+    from alphapulldown_input_parser.parser import FoldDataset
+
+    ds = FoldDataset.from_fold_specifications(
+        ["P12345+ligand.json:80", "/data/Prot.fasta+Q99999"],
+        protein_delimiter="+",
+    )
+
+    # .json preserved (path dropped, copy-number suffix kept); protein path+ext -> stem.
+    assert ds.fold_specifications == ("P12345+ligand.json:80", "Prot+Q99999")
+    assert ds.sequences_by_fold["P12345+ligand.json:80"] == ("P12345", "ligand.json")
+    assert ds.sequences_by_fold["Prot+Q99999"] == ("Prot", "Q99999")
+
+    # A bare ligand JSON keeps its extension too.
+    ds_single = FoldDataset.from_fold_specifications(["ligand.json"], protein_delimiter="+")
+    assert ds_single.fold_specifications == ("ligand.json",)


### PR DESCRIPTION
## Why

`FoldDataset.from_fold_specifications` stripped the extension from **every** token via `_strip_path_and_extension` (`Path(value).stem`). So an AF3 JSON input like `ligand.json` was normalized to `ligand` and became indistinguishable from a protein named `ligand`.

This is the root cause of **KosinskiLab/AlphaPulldownSnakemake#41**: the Snakemake wrapper derives its `download_uniprot` / `create_features` targets from `dataset.fold_specifications` / `sequences_by_fold`, so a ligand JSON was scheduled for UniProt download + feature generation instead of being used directly as an AF3 input.

(The standalone AlphaPulldown CLI is unaffected — it uses `parse_fold`, whose JSON branch already handles `.json` inputs correctly.)

## What

- New helper `_normalize_reference_name`: drops only the **directory** for `*.json` tokens and **keeps the `.json` extension**; any other reference is still reduced to its stem (unchanged protein behaviour).
- `FoldDataset.from_fold_specifications` now uses it, so `dataset.fold_specifications` / `sequences_by_fold` retain `.json` markers.
- Bump `0.5.0` → `0.5.1`.

Examples:

| input | normalized fold spec (before) | normalized fold spec (after) |
|---|---|---|
| `P12345+ligand.json:80` | `P12345+ligand:80` | `P12345+ligand.json:80` |
| `/data/Prot.fasta+Q99999` | `Prot+Q99999` | `Prot+Q99999` (unchanged) |

## Scope / safety

This touches **only** `FoldDataset`. `parse_fold`, `parse_fold_chains`, `expand_fold_specification`, and `generate_fold_specifications` are untouched. Audited all three repos: **AlphaPulldown does not use `FoldDataset`** (only `parse_fold` / `generate_fold_specifications` / `RegionSelection`), and the only `FoldDataset` consumer is the AlphaPulldownSnakemake `Snakefile` (updated in tandem — see its PR pinning `>=0.5.1`).

## Tests

- New `test_fold_dataset_preserves_json_extension`.
- Full suite green: `27 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)